### PR TITLE
Support for multi-line titles

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -81,7 +81,8 @@
     [item setTarget:self];
   }
   BOOL parseANSI = [fullTitle containsANSICodes] && ![[params[@"ansi"] lowercaseString] isEqualToString:@"false"];
-  if (params[@"font"] || params[@"size"] || params[@"color"] || parseANSI)
+  BOOL multiline = [fullTitle rangeOfString:@"\\n"].location != NSNotFound;
+  if (params[@"font"] || params[@"size"] || params[@"color"] || parseANSI || multiline)
     item.attributedTitle = [self attributedTitleWithParams:params];
   
   if (params[@"alternate"]) {
@@ -100,6 +101,7 @@
 - (NSAttributedString*) attributedTitleWithParams:(NSDictionary *)params {
 
   NSString * fullTitle = params[@"title"];
+  fullTitle = [fullTitle stringByReplacingOccurrencesOfString:@"\\n" withString:@"\n"];
   if (![[params[@"emojize"] lowercaseString] isEqualToString:@"false"]) {
     fullTitle = [fullTitle emojizedString];
   }


### PR DESCRIPTION
  echo "DISK\n16% | size=7 templateImage=..."
will be rendered on the menubar (or dropdown) as a single block of two lines. Closes #264.

Menu bar space is always at a premium. The same label expanded would occupy much more space. While readability vs space is a tradeoff which must be carefully considered, this feature gives plugin writers a wider field to experiment.

<img width="323" alt="screen shot 2016-04-19 at 8 29 54 am" src="https://cloud.githubusercontent.com/assets/827790/14626447/0a1e6918-0609-11e6-98ac-b2693bbc80af.png">
