### PR TITLE
Potential fix for #88: Read from a config.json file

### DIFF
--- a/App/BitBar/PluginManager.m
+++ b/App/BitBar/PluginManager.m
@@ -305,7 +305,17 @@
 
     NSMutableDictionary *env = NSProcessInfo.processInfo.environment.mutableCopy;
     env[@"BitBar"] = @YES;
+    
+    // Read a config file from disk and add it to our environment
+    NSString *configPath = [NSString stringWithFormat:@"%@/config.json", self.path];
+    env[@"CONFIG_PATH"] = configPath;
+    
+    if([[NSFileManager defaultManager] fileExistsAtPath:configPath]) {
+      NSData *data = [[NSFileManager defaultManager] contentsAtPath:configPath];
+      [env addEntriesFromDictionary:[NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil]];
       
+    }
+    
     // Determine if Mac is in Dark Mode
     NSString *osxMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
     if ([osxMode isEqualToString:@"Dark"]) {


### PR DESCRIPTION
I wanted a way to separate configuration from code, so this is an
attempt to do so.

Reads configuration from a `config.json` file in the bitbar plugin
directory, and loads it into the environment of the script so that it's
available to plugins.

This is probably the most lines of Objective-C I've ever written in one
sitting. Feel free to critique.
