### PR TITLE
Do less per refresh cycle to bring down CPU usage

### DIFF
--- a/App/BitBar/ExecutablePlugin.m
+++ b/App/BitBar/ExecutablePlugin.m
@@ -85,8 +85,6 @@
         
         strongSelf.lastUpdated = NSDate.new;
         
-        [strongSelf rebuildMenuForStatusItem:strongSelf.statusItem];
-        
         // reset the current line
         strongSelf.currentLine = -1;
         

--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -259,8 +259,14 @@
 
 - (void) rebuildMenuForStatusItem:(NSStatusItem*)statusItem {
   // build the menu
-  NSMenu *menu = NSMenu.new;
-  [menu setDelegate:self];
+  NSMenu * menu = statusItem.menu;
+  if (menu == nil) {
+    menu = NSMenu.new;
+    statusItem.menu = menu;
+    menu.delegate = self;
+  }
+  
+  [menu removeAllItems];
   
   if (self.isMultiline) {
     
@@ -315,14 +321,11 @@
               [submenu addItem:item];
           }
         }
-        
       }
       
       // add the seperator
       [menu addItem:[NSMenuItem separatorItem]];
-      
     }
-    
   }
   
   if (self.lastUpdated != nil) {
@@ -333,10 +336,6 @@
   
   [self addAdditionalMenuItems:menu];
   [self addDefaultMenuItems:menu];
-  
-  // set the menu
-  statusItem.menu = menu;
-  
 }
 
 - (void) addDefaultMenuItems:(NSMenu *)menu {


### PR DESCRIPTION
Don’t rebuild the menu on every refresh, just rebuild when the open is about to be opened
Cache the attributed text

This brings my CPU usage form 1.5 - 2% to .2% - .1%.  It needs some cleanup so maybe someone could run with it.