### PR TITLE
Add ToolTip feature

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -93,6 +93,10 @@
   }else if (params[@"image"]) {
     item.image = [self createImageFromBase64:params[@"image"] isTemplate:false];
   }
+    
+  if (params[@"tooltip"]) {
+    item.toolTip = params[@"tooltip"];
+  }
 
   return item;
 }


### PR DESCRIPTION
Add a tooltip feature.

This feature may be used like this:

```python
print "This is a menu item | tooltip='This is a Tooltip' "
```

Resulting in:

![image](https://user-images.githubusercontent.com/5826484/28681275-edee8fc6-72c6-11e7-8c6a-9f3776c9ede7.png)
