### PR TITLE
Fix a link to URL scheme example

### DIFF
--- a/Docs/URLScheme.md
+++ b/Docs/URLScheme.md
@@ -11,7 +11,7 @@ Query parameters:
 
 - `src` Source URL
 
-Examples: see [test page](App/BitBar/incoming-url-tests.html)
+Examples: see [test page](../App/BitBar/incoming-url-tests.html)
 
 ## refreshPlugin
 


### PR DESCRIPTION
The current link to the URL scheme for opening a plugin gives me a 404. It seems that the project was re-organised and it somehow slipped.