### PR TITLE
Make building simpler

### DIFF
--- a/App/BitBar.xcodeproj/project.pbxproj
+++ b/App/BitBar.xcodeproj/project.pbxproj
@@ -180,6 +180,13 @@
 			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
 			remoteInfo = Sparkle;
 		};
+		A45032062231846500070F29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36D0CDF21D0AF009001AFB77 /* Sparkle.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 722954B41D04ADAF00ECF9CA;
+			remoteInfo = fileop;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -426,6 +433,7 @@
 				36D0CE051D0AF009001AFB77 /* BinaryDelta */,
 				36D0CE071D0AF009001AFB77 /* Autoupdate.app */,
 				36D0CE091D0AF009001AFB77 /* UI Tests.xctest */,
+				A45032072231846500070F29 /* fileop */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -667,6 +675,13 @@
 			fileType = wrapper.cfbundle;
 			path = "UI Tests.xctest";
 			remoteRef = 36D0CE081D0AF009001AFB77 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		A45032072231846500070F29 /* fileop */ = {
+			isa = PBXReferenceProxy;
+			fileType = "compiled.mach-o.executable";
+			path = fileop;
+			remoteRef = A45032062231846500070F29 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -930,6 +945,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
+				HEADER_SEARCH_PATHS = "./Vendor/**";
 				INFOPLIST_FILE = "BitBar/BitBar-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
@@ -945,6 +961,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
+				HEADER_SEARCH_PATHS = "./Vendor/**";
 				INFOPLIST_FILE = "BitBar/BitBar-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;

--- a/App/BitBar.xcodeproj/project.pbxproj
+++ b/App/BitBar.xcodeproj/project.pbxproj
@@ -180,13 +180,6 @@
 			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
 			remoteInfo = Sparkle;
 		};
-		A45032062231846500070F29 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36D0CDF21D0AF009001AFB77 /* Sparkle.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 722954B41D04ADAF00ECF9CA;
-			remoteInfo = fileop;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -433,7 +426,6 @@
 				36D0CE051D0AF009001AFB77 /* BinaryDelta */,
 				36D0CE071D0AF009001AFB77 /* Autoupdate.app */,
 				36D0CE091D0AF009001AFB77 /* UI Tests.xctest */,
-				A45032072231846500070F29 /* fileop */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -675,13 +667,6 @@
 			fileType = wrapper.cfbundle;
 			path = "UI Tests.xctest";
 			remoteRef = 36D0CE081D0AF009001AFB77 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A45032072231846500070F29 /* fileop */ = {
-			isa = PBXReferenceProxy;
-			fileType = "compiled.mach-o.executable";
-			path = fileop;
-			remoteRef = A45032062231846500070F29 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 PROJECT_NAME ?= BitBar
-PROJECT = $(shell find . -name '*.xcodeproj')
+PROJECT = $(shell find . -name 'BitBar.xcodeproj')
 
 all: build
 
@@ -8,6 +8,7 @@ clean:
 	rm -r ./**/build
 
 build:
+	git submodule init && git submodule update
 	xcodebuild -project $(PROJECT)
 	ps aux | grep $(PROJECT_NAME) | grep -v grep >/dev/null 2>&1 && killall $(PROJECT_NAME)
 	open $(PROJECT)/../build/Release/$(PROJECT_NAME).app

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ In terminal, navigate to the project directory and run:
 git submodule init && git submodule update
 ```
 
+To build run:
+
+```
+make
+```
+
 ## Thanks
 
   * Special thanks to [@muhqu](https://github.com/muhqu) and [@tylerb](https://github.com/tylerb) for all their help (see commit history for details)


### PR DESCRIPTION
This pull makes building the project a bit easier to those new to the codebase. 

- Adds `./Vendor/**` to the header search paths
- Updates the `Makefile` to fetch the git submodules
- Updates the `Makefile` to only build BitBar, it doesn't appear the submodules require building
- Notes to run `make` in the README to build the project