### PR TITLE
add `path` param that you can specify PATH for bash script

### DIFF
--- a/App/BitBar/Plugin.m
+++ b/App/BitBar/Plugin.m
@@ -200,7 +200,11 @@
     
     [(NSTask*)task setLaunchPath:params[@"bash"]];
     [(NSTask*)task setArguments:params[@"args"]];
-    
+    NSString *path = params[@"path"];
+    if(path != nil) {
+      [(NSTask*)task setEnvironment:@{@"PATH": path}];
+    }
+  
     ((NSTask*)task).terminationHandler = ^(NSTask *task) {
       if (params[@"refresh"]) {
         [self performSelectorOnMainThread:@selector(performRefreshNow) withObject:NULL waitUntilDone:false];
@@ -233,11 +237,15 @@
       argArray.copy;
 
     });
-    
+    NSString *path = params[@"path"];
+  
     if([terminal isEqual: @"false"]){
       NSLog(@"Args: %@", args);
       [params setObject:bash forKey:@"bash"];
       [params setObject:args forKey:@"args"];
+      if(path != nil) {
+        [params setObject:path forKey:@"path"];
+      }
       [self performSelectorInBackground:@selector(startTask:) withObject:params];
     } else {
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ If you want to contribute, please send us a pull request and we'll add it to our
     * `size=..` to change their text size. eg. `size=12`
     * `bash=..` to make the item run a given script terminal with your script e.g. `bash=/Users/user/BitBar_Plugins/scripts/nginx.restart.sh` if there are spaces in the file path you will need quotes e.g. `bash="/Users/user/BitBar Plugins/scripts/nginx.restart.sh"`
     * `param1=` to specify arguments to the script. additional params like this `param2=foo param3=bar` full example  `bash="/Users/user/BitBar_Plugins/scripts/nginx.restart.sh" param1=--verbose` assuming that nginx.restart.sh is executable or `bash=/usr/bin/ruby param1=/Users/user/rubyscript.rb param2=arg1 param3=arg2` if script is not executable
+    * `path=` to specify `PATH` for the bash script.
     * `terminal=..` start bash script without opening Terminal. `true` or `false`
     * `refresh=..` to make the item refresh the plugin it belongs to. If the item runs a script, refresh is performed after the script finishes. eg. `refresh=true`
     * `dropdown=..` May be set to `true` or `false`. If `false`, the line will only appear and cycle in the status bar but not in the dropdown


### PR DESCRIPTION
Hi,
I created this PR because I thought it would be nice if we could specify PATH referenced by a bash script.

In my case, I'm now trying to run the following python script (`hello.py`):

```python
#!/usr/bin/env python3
print("hello")
```

via the following script that is executed by the BitBar:

```
#!/usr/bin/env bash
echo "Hello | dropdown=false"
echo "run hello | terminal=true bash=~/hello.py
```

However, this doesn't work because the system can't find Python 3. Python 3 is not pre-installed so we have to specify PATH for it. Of course, specifying the actual path of `python3` can be a solution, but it's less portable.

This PR will let us specify that PATH like this:

```
#!/usr/bin/env bash
echo "Hello | dropdown=false"
echo "run hello | terminal=true bash=~/hello.py path=$PATH:/usr/local/bin"
```