### PR TITLE
Info.plist updates.

### DIFF
--- a/app/assets/mac/Info.plist.src
+++ b/app/assets/mac/Info.plist.src
@@ -3,7 +3,7 @@
 	<key>CFBundlePackageType</key><string>APPL</string>
 	<key>CFBundleName</key><string>xbar</string>
 	<key>CFBundleExecutable</key><string>xbar</string>
-	<key>CFBundleIdentifier</key><string>xbar.0.0.0</string>
+	<key>CFBundleIdentifier</key><string>matryer.xbar</string>
 	<key>CFBundleVersion</key><string>0.0.0</string>
 	<key>CFBundleURLTypes</key>
     	<array>

--- a/app/go.mod
+++ b/app/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/matryer/xbar/pkg/update v0.0.0-00010101000000-000000000000
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/wailsapp/wails/v2 v2.0.0-alpha.62
+	github.com/wailsapp/wails/v2 v2.0.0-alpha.63
 	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d // indirect
 )
 

--- a/app/go.sum
+++ b/app/go.sum
@@ -99,8 +99,8 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/wailsapp/wails/v2 v2.0.0-alpha.62 h1:MtcgSY4vVj/Al/wMpyEJZXI2xOGBXGNpH47JSABgRts=
-github.com/wailsapp/wails/v2 v2.0.0-alpha.62/go.mod h1:Yc65JRHZwCwYfBTaemkOzN7nOl2e1iBVZMzEVPxsQ9s=
+github.com/wailsapp/wails/v2 v2.0.0-alpha.63 h1:dMSFvEd7+DbKNJ/lOAF3A8/2FJuF1u2ujFZxcNXvMTc=
+github.com/wailsapp/wails/v2 v2.0.0-alpha.63/go.mod h1:Yc65JRHZwCwYfBTaemkOzN7nOl2e1iBVZMzEVPxsQ9s=
 github.com/wzshiming/ctc v1.2.3/go.mod h1:2tVAtIY7SUyraSk0JxvwmONNPFL4ARavPuEsg5+KA28=
 github.com/wzshiming/winseq v0.0.0-20200112104235-db357dc107ae/go.mod h1:VTAq37rkGeV+WOybvZwjXiJOicICdpLCN8ifpISjK20=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=

--- a/app/package.sh
+++ b/app/package.sh
@@ -19,7 +19,7 @@ echo -n $VERSION > .version
 
 rm -rf ./build
 
-sed "s/0.0.0/${VERSION}/" ./assets/mac/info.plist.src > ./assets/mac/info.plist
+sed "s/0.0.0/${VERSION}/" ./assets/mac/Info.plist.src > ./assets/mac/Info.plist
 CGO_LDFLAGS=-mmacosx-version-min=10.13 wails build -package -production -platform darwin/amd64
 #CGO_LDFLAGS=-mmacosx-version-min=10.13 wails build -package -production -platform darwin/arm64
 #CGO_LDFLAGS=-mmacosx-version-min=10.13 wails build -package -production -platform darwin/universal


### PR DESCRIPTION
* Removes version from CFBundleIdentifier
* Uses `matryer.xbar` as CFBundleIdentifier (you may want to change this?)
* Uses `Info.plist` instead of `info.plist`
* Uses Wails alpha.63 which now uses `Info.plist` instead of `info.plist`

Make sure you do the following:
- `wails update -pre`
- Delete the local `info.plist` in the `app/assets/mac` directory if it exists