### PR TITLE
Fixes PluginView flex layout issue causing plugin information and install button to be obstructed by the source section

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -12,14 +12,28 @@ To build xbar, you will need:
 
 ### Running
 
+If running for the first time first generate the `.version` file and install the npm dependencies by running: 
+
 ```bash
-cd app && wails dev
+cd app && git describe --tags > .version 
+```
+
+and 
+
+```bash
+cd app/frontend && npm install
+```
+
+To start the application run:
+
+```bash
+cd app/frontend && npm run dev
 ```
 
 and
 
-```
-cd app/frontend && npm run dev
+```bash
+cd app && wails dev
 ```
 
 ### Building

--- a/app/frontend/src/PluginView.svelte
+++ b/app/frontend/src/PluginView.svelte
@@ -45,6 +45,10 @@
 	.plugin-image {
 		max-width: 300px;
 	}
+
+	.min-height-m-c {
+		min-height: min-content;
+	}
 </style>
 
 <Error err={err} />
@@ -55,7 +59,7 @@
 
 {#if plugin}
 	<div class='flex flex-col h-full max-w-full'>
-		<div class='p-6 flex flex-wrap space-x-8'>
+		<div class='p-6 flex flex-wrap space-x-8 min-height-m-c'>
 			<div>
 				<PluginDetails plugin={plugin} />
 				<p class='p-3'>


### PR DESCRIPTION
In the plugin detail view (after clicking on the plugin) in the plugin browser app the source code viewer covers up the plugin information, image and install button making the app difficult to use. When viewing this screen in Chrome it renders as expected but in the XBar executable built by Wails and in Safari (Wails must leverage Safari) the issue is visible - see screen shot below. 

This PR adds a css class to PluginView.svelte that limits the min-height property on the info section of the view to the minimum height of its content to ensure the height of the info section doesn't shrink leading to the overlap of the source section. 

I also ran into a couple things when running the project for the first time that I added to the "Running" section of the README that might be useful to the next person. 


Issue presenting before style change: 

<img width="1086" alt="xbar-layout-before" src="https://user-images.githubusercontent.com/6668160/115159358-c22d8600-a060-11eb-91bd-694af929c53b.png">

After the style change: 

<img width="1087" alt="xbar-layout-after" src="https://user-images.githubusercontent.com/6668160/115159375-da050a00-a060-11eb-9ffd-29be6c52a89e.png">

-Cam

