### PR TITLE
Fix links to the writing plugins guide at xbar-plugins

### DIFF
--- a/app/frontend/src/App.svelte
+++ b/app/frontend/src/App.svelte
@@ -58,7 +58,7 @@
 
 	function openPluginGuide(event) {
 		event.preventDefault()
-		openURL('https://github.com/matryer/xbar#writing-plugins')
+		openURL('https://github.com/matryer/xbar-plugins/blob/main/CONTRIBUTING.md')
 			.catch(e => err = e)
 	}
 

--- a/xbarapp.com/templates/_layout.html
+++ b/xbarapp.com/templates/_layout.html
@@ -99,7 +99,7 @@
 					<div>
 						<a target='github' class='hover:underline hover:text-white' href='https://github.com/matryer/xbar'>GitHub project</a>
 						•
-						<a target='github' class='hover:underline hover:text-white' href='https://github.com/matryer/xbar#writing-plugins'>Writing plugins guide</a>
+						<a target='github' class='hover:underline hover:text-white' href='https://github.com/matryer/xbar-plugins/blob/main/CONTRIBUTING.md'>Writing plugins guide</a>
 					</div>
 					<div class='mt-8'>
 						<a target='github' class='hover:underline' href='https://github.com/matryer/xbar/blob/master/LICENSE.txt'>MIT License</a> • <a target='twitter' class='hover:underline hover:text-white' href='https://twitter.com/matryer'>@matryer</a>

--- a/xbarapp.com/templates/articles-index.html
+++ b/xbarapp.com/templates/articles-index.html
@@ -35,7 +35,7 @@
 						</h2>
 						<ul class='list-style-disc'>
 							<li>
-								－<a class='hover:underline' href='https://github.com/matryer/xbar#writing-plugins'>Writing plugins guide</a>
+								－<a class='hover:underline' href='https://github.com/matryer/xbar-plugins/blob/main/CONTRIBUTING.md'>Writing plugins guide</a>
 							</li>
 							<li>
 								－<a class='hover:underline' href='https://github.com/matryer/xbar#parameters'>Parameters</a>


### PR DESCRIPTION
Some links still pointed to 
https://github.com/matryer/xbar#writing-plugins
instead of
https://github.com/matryer/xbar-plugins/blob/main/CONTRIBUTING.md.