### PR TITLE
Fix path to binary

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -41,7 +41,7 @@ cd app && wails dev
 In this directory run `./build.sh`. The binary will be generated in `./build/darwin/desktop/`.
 
 ```bash
-./build.sh && ./build/darwin/desktop/xbar
+./build.sh && ./build/bin/xbar
 ```
 
 ### Updates


### PR DESCRIPTION
This pull request updates the documentation to use the binary path when using Wails CLI v2.0.0-alpha.72.