### PR TITLE
Fix path to binary

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -38,7 +38,7 @@ cd app && wails dev
 
 ### Building
 
-In this directory run `./build.sh`. The binary will be generated in `./build/darwin/desktop/`.
+In this directory run `./build.sh`. The binary will be generated in `./build/bin/`.
 
 ```bash
 ./build.sh && ./build/bin/xbar


### PR DESCRIPTION
This pull request fixes the path to the binary in the documentation as well as the code block in #827.