### PR TITLE
Fix missing images

### DIFF
--- a/app/frontend/src/elements/PluginCollection.svelte
+++ b/app/frontend/src/elements/PluginCollection.svelte
@@ -60,14 +60,16 @@
 						</a>
 					</h2>
 					<div class='flex'>
-						<a href='#/plugin-details/{plugin.path}'>
-							<img 
-								class='plugin-pic float-left m-4 mr-0'
-								alt='Photo for {plugin.title}' 
-								src='{plugin.imageURL}'
-								onerror='this.style.display="none"'
-							>
-						</a>
+						{#if plugin.imageURL}
+							<a href='#/plugin-details/{plugin.path}'>
+								<img
+									class='plugin-pic float-left m-4 mr-0'
+									alt='Photo for {plugin.title}'
+									src='{plugin.imageURL}'
+									onerror='this.style.display="none"'
+								>
+							</a>
+						{/if}
 						<p class='plugin-desc mb-2 p-4 test-gray break-words'>
 							{plugin.desc}
 						</p>


### PR DESCRIPTION
This pull request checks if a plugin has an image before including an image tag.

Before:
<img width="1192" alt="Screenshot 2023-04-09 at 17 14 54" src="https://user-images.githubusercontent.com/2276355/230782744-d05b5e2c-b2e4-46cc-b54f-e192f91fde95.png">

After:
<img width="1192" alt="Screenshot 2023-04-09 at 17 15 26" src="https://user-images.githubusercontent.com/2276355/230782747-42091f0e-640f-42e9-9bda-fb7ca8977c64.png">
