### PR TITLE
Fix source code viewer

### DIFF
--- a/app/frontend/src/elements/PluginSourceBrowser.svelte
+++ b/app/frontend/src/elements/PluginSourceBrowser.svelte
@@ -26,10 +26,6 @@
                 </div>
             {/if}
         </div>
-        <pre class='whitespace-pre-wrap nice-wrapping text-sm pb-8'>
-            <code>
-                {file.content}
-            </code>
-        </pre>
+        <pre class='whitespace-pre-wrap nice-wrapping text-sm pb-8'><code>{file.content}</code></pre>
     {/each}
 {/if}


### PR DESCRIPTION
This pull request removes the whitespace around the source code that causes unwanted indentation.

Before:
<img width="1192" alt="Screenshot 2023-04-09 at 17 36 04" src="https://user-images.githubusercontent.com/2276355/230782807-2ed91c1a-8346-43a3-9f60-fa843d3f8a4a.png">

After:
<img width="1192" alt="Screenshot 2023-04-09 at 17 37 57" src="https://user-images.githubusercontent.com/2276355/230782808-75208652-5dc6-43b5-9a09-0274b1e6ad1c.png">
